### PR TITLE
Refactor timestamp conversion to UTC seconds

### DIFF
--- a/GNN/LeGNN_output.py
+++ b/GNN/LeGNN_output.py
@@ -10,6 +10,7 @@ from torch_geometric.loader import HGTLoader
 from torch_geometric.nn import SAGEConv
 from contextlib import contextmanager
 from pathlib import Path
+from GNN.time_utils import convert_to_utc_seconds as _convert_to_utc_seconds_list
 
 # utilities
 def setup_logging():
@@ -90,38 +91,10 @@ def alarm():
         time.sleep(0.5)
 
 # preprocessing
-def safe_normalize_timestamps(timestamps, eps=1e-8):
-    timestamps = torch.nan_to_num(timestamps, nan=0.0, posinf=1e4, neginf=-1e4)
-    p5 = torch.quantile(timestamps, 0.05)
-    p95 = torch.quantile(timestamps, 0.95)
+def convert_to_utc_seconds(time_data):
+    """Convert timestamp-like values to a torch tensor of UTC seconds."""
 
-    if (p95 - p5) < eps:
-        return torch.zeros_like(timestamps)
-
-    timestamps = torch.clamp(timestamps, p5, p95)
-    normalized = (timestamps - p5) / (p95 - p5)
-    return torch.nan_to_num(normalized, nan=0.0)
-
-def safe_standardize_time_format(time_data):
-    times = []
-    for t in time_data:
-        try:
-            if isinstance(t, (int, float)) and 1900 <= t  and t <= 2100:
-                td = datetime.datetime(int(t), 6, 15).timestamp()
-            elif (isinstance(t, str) or (isinstance(t, float))) and (float(t) < 2100 and float(t) > 1900):
-                td = datetime.datetime(int(float(t)), 6, 15).timestamp()
-            elif float(t) > 0 and float(t) < 1990:
-                td = t
-            elif float(t) > 17000000.0:
-                td = float(t)
-            elif isinstance(t, datetime.datetime):
-                td = t.timestamp()
-            else:
-                td = float(t) * 1e9
-        except:
-            td = datetime.datetime(2000, 6, 15).timestamp()
-        times.append(td)
-    return torch.tensor(times, dtype=torch.float32)
+    return torch.tensor(_convert_to_utc_seconds_list(time_data), dtype=torch.float32)
 
 def pull_timestamps(data):
     timestamp_edges = [
@@ -141,9 +114,8 @@ def pull_timestamps(data):
             if data[et].edge_attr.size(1) > 1:
                 edge_attr = data[et].edge_attr
                 ts_col = edge_attr[:, -1]
-                if ts_col.abs().max() > 1e8 or ts_col.min() < 0:
-                    ts_col = safe_standardize_time_format(ts_col.tolist()).to(edge_attr.device)
-                data[et].timestamp = safe_normalize_timestamps(ts_col)
+                ts_seconds = convert_to_utc_seconds(ts_col).to(edge_attr.device)
+                data[et].timestamp = ts_seconds
                 data[et].edge_attr = edge_attr[:, :-1]
 
     for nt in timestamp_nodes:
@@ -153,10 +125,9 @@ def pull_timestamps(data):
                     if data[nt].x.size(1) > 1:
                         x = data[nt].x
                         ts_col = x[:, -1]
-                        if ts_col.abs().max() > 1e8 or ts_col.min() < 0:
-                            ts_col = safe_standardize_time_format(ts_col.tolist()).to(x.device)
-                        if nt in timestamp_nodes or ts_col.abs().max() > 1e6:
-                            data[nt].timestamp = safe_normalize_timestamps(ts_col)
+                        ts_seconds = convert_to_utc_seconds(ts_col).to(x.device)
+                        if nt in timestamp_nodes or ts_seconds.abs().max() > 1e6:
+                            data[nt].timestamp = ts_seconds
                             data[nt].x = x[:, :-1]
             except:
                 pass

--- a/GNN/__init__.py
+++ b/GNN/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities and models for graph neural networks."""
+
+from .time_utils import convert_to_utc_seconds
+
+__all__ = ["convert_to_utc_seconds"]

--- a/GNN/time_utils.py
+++ b/GNN/time_utils.py
@@ -1,0 +1,119 @@
+"""Utilities for normalizing heterogeneous timestamp inputs."""
+
+from __future__ import annotations
+
+import datetime
+import math
+from typing import Iterable, List
+
+try:  # Optional dependency used only when available.
+    import numpy as np
+except ImportError:  # pragma: no cover - numpy is present in production environment.
+    np = None  # type: ignore[assignment]
+
+try:  # Optional dependency used only when available.
+    import torch
+except ImportError:  # pragma: no cover - torch is present in production environment.
+    torch = None  # type: ignore[assignment]
+
+
+_FALLBACK_TIMESTAMP = datetime.datetime(2000, 6, 15, tzinfo=datetime.timezone.utc).timestamp()
+
+
+def _datetime_to_utc_seconds(dt: datetime.datetime) -> float:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    else:
+        dt = dt.astimezone(datetime.timezone.utc)
+    return dt.timestamp()
+
+
+def _numeric_to_utc_seconds(value: float) -> float:
+    if not math.isfinite(value):
+        raise ValueError("Non-finite numeric timestamp")
+
+    rounded_year = round(value)
+    if 1900 <= rounded_year <= 2100 and abs(value - rounded_year) < 1e-6:
+        return _datetime_to_utc_seconds(datetime.datetime(rounded_year, 6, 15))
+
+    abs_value = abs(value)
+    if abs_value >= 1e18:
+        return value / 1e9
+    if abs_value >= 1e15:
+        return value / 1e6
+    if abs_value >= 1e12:
+        return value / 1e3
+    return value
+
+
+def _string_to_utc_seconds(value: str) -> float:
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError("Empty timestamp string")
+
+    iso_candidate = stripped[:-1] + '+00:00' if stripped.endswith('Z') else stripped
+    try:
+        dt = datetime.datetime.fromisoformat(iso_candidate)
+    except ValueError:
+        dt = None
+
+    if dt is not None:
+        return _datetime_to_utc_seconds(dt)
+
+    numeric_value = float(stripped)
+    return _numeric_to_utc_seconds(numeric_value)
+
+
+def _as_iterable(time_data) -> Iterable:
+    if torch is not None and isinstance(time_data, torch.Tensor):
+        return time_data.detach().cpu().view(-1).tolist()
+    if np is not None and isinstance(time_data, np.ndarray):
+        return np.asarray(time_data).reshape(-1).tolist()
+    if isinstance(time_data, (list, tuple)):
+        return list(time_data)
+    try:
+        return list(time_data)
+    except TypeError:
+        return [time_data]
+
+
+def convert_to_utc_seconds(time_data) -> List[float]:
+    """Normalize timestamps to UTC seconds since the Unix epoch.
+
+    The function accepts inputs commonly seen in the dataset:
+
+    * ``datetime`` objects (naive timestamps are assumed to be UTC).
+    * Numeric epochs expressed in seconds, milliseconds, microseconds,
+      or nanoseconds. Magnitude heuristics are used to infer the unit.
+    * Year-only values as numbers or strings between 1900 and 2100;
+      these are mapped to June 15 of the given year to provide a stable
+      mid-year reference point.
+    * ISO-8601 formatted strings, including those with trailing ``"Z"``.
+
+    Any value that fails to parse (including NaNs) is replaced with a
+    fallback timestamp corresponding to 2000-06-15 00:00:00 UTC.
+    """
+
+    iterable = _as_iterable(time_data)
+    times: List[float] = []
+
+    for item in iterable:
+        try:
+            if isinstance(item, datetime.datetime):
+                ts = _datetime_to_utc_seconds(item)
+            elif isinstance(item, str):
+                ts = _string_to_utc_seconds(item)
+            elif isinstance(item, (int, float)):
+                ts = _numeric_to_utc_seconds(float(item))
+            elif torch is not None and isinstance(item, torch.Tensor):
+                ts = _numeric_to_utc_seconds(float(item.item()))
+            else:
+                raise ValueError("Unsupported timestamp type")
+        except Exception:
+            ts = _FALLBACK_TIMESTAMP
+        times.append(float(ts))
+
+    return times
+
+
+__all__ = ["convert_to_utc_seconds", "_FALLBACK_TIMESTAMP"]

--- a/tests/test_time_conversion.py
+++ b/tests/test_time_conversion.py
@@ -1,0 +1,40 @@
+import datetime
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from GNN.time_utils import convert_to_utc_seconds
+
+
+def test_year_only_strings_use_midyear_timestamp():
+    timestamps = ["1999", "2005"]
+    result = convert_to_utc_seconds(timestamps)
+
+    expected = [
+        datetime.datetime(1999, 6, 15, tzinfo=datetime.timezone.utc).timestamp(),
+        datetime.datetime(2005, 6, 15, tzinfo=datetime.timezone.utc).timestamp(),
+    ]
+
+    assert result == pytest.approx(expected)
+
+
+def test_epoch_seconds_pass_through_unchanged():
+    epoch_values = [1_600_000_000.0, 1_620_000_000.5]
+    result = convert_to_utc_seconds(epoch_values)
+
+    assert result == pytest.approx(epoch_values)
+
+
+def test_nan_inputs_fall_back_to_default_timestamp():
+    timestamps = [float("nan"), 1_600_000_000.0]
+    result = convert_to_utc_seconds(timestamps)
+
+    fallback = datetime.datetime(2000, 6, 15, tzinfo=datetime.timezone.utc).timestamp()
+
+    assert result[0] == pytest.approx(fallback)
+    assert result[1] == pytest.approx(1_600_000_000.0)


### PR DESCRIPTION
## Summary
- add a shared timestamp conversion utility that converts heterogeneous inputs to UTC seconds and documents supported formats
- update the GNN preprocessing code to use the new converter instead of the legacy normalization helpers
- cover year strings, epoch floats, and NaN fallbacks with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c85b33f3c0832499241161abc7d16d