### PR TITLE
Enhance controversy calculation with abstentions

### DIFF
--- a/GNN/LeGNN.py
+++ b/GNN/LeGNN.py
@@ -150,7 +150,32 @@ def clean_features(data):
     data = pull_timestamps(data)
     return data
 
-def compute_controversiality(data):
+def compute_controversiality(
+    data,
+    *,
+    session_attr=None,
+    total_possible_attr=None,
+):
+    """Compute controversy scores for bill versions based on vote signals.
+
+    Parameters
+    ----------
+    data:
+        Heterogeneous graph data containing a ``('legislator_term', 'voted_on',
+        'bill_version')`` edge type with a vote signal stored in
+        ``edge_attr``.
+    session_attr:
+        Optional attribute (name or tensor) that encodes the legislative
+        session or year for each bill version. When provided, the function
+        will aggregate controversy statistics per session in addition to the
+        per-bill values.
+    total_possible_attr:
+        Attribute (name, tensor, or mapping) describing the total possible
+        votes for each bill version (for example, committee size or chamber
+        membership). When omitted, the function falls back to the observed
+        vote counts (yes + no + abstain).
+    """
+
     edge_type = ('legislator_term', 'voted_on', 'bill_version')
     if edge_type not in data.edge_index_dict:
         raise ValueError("Missing 'voted_on' edges in data.")
@@ -158,32 +183,199 @@ def compute_controversiality(data):
     ei = data[edge_type].edge_index
     ea = data[edge_type].edge_attr
 
-    vote_signal = ea[:, 0]
+    vote_signal = ea[:, 0].to(torch.float32)
 
-    src_nodes = ei[0]
     tgt_nodes = ei[1]
 
     num_bills = data['bill_version'].num_nodes
-    device = tgt_nodes.device
+    device = vote_signal.device
 
-    yes_votes = torch.zeros(num_bills, device=device)
-    no_votes = torch.zeros(num_bills, device=device)
+    def _to_tensor(value, *, length=None):
+        if value is None:
+            return None
+        if isinstance(value, torch.Tensor):
+            tensor = value
+        elif isinstance(value, np.ndarray):
+            tensor = torch.from_numpy(value)
+        elif isinstance(value, (list, tuple)):
+            tensor = torch.tensor(value)
+        elif isinstance(value, (int, float)):
+            tensor = torch.tensor([float(value)])
+        else:
+            return None
+
+        tensor = tensor.to(device=device, dtype=torch.float32)
+        if tensor.dim() == 0:
+            tensor = tensor.unsqueeze(0)
+        if length is not None:
+            if tensor.numel() == 1 and length > 1:
+                tensor = tensor.repeat(length)
+            elif tensor.numel() != length:
+                return None
+        return tensor.view(-1)
+
+    def _fetch_store_attr(store, name):
+        if not isinstance(name, str):
+            return None
+        value = getattr(store, name, None)
+        if value is None:
+            try:
+                value = store[name]
+            except (KeyError, AttributeError, TypeError):
+                value = None
+        return value
+
+    def _normalize_session_key(key):
+        if isinstance(key, (int, float)):
+            return int(key)
+        if isinstance(key, str):
+            candidate = key.strip()
+            if candidate.isdigit():
+                return int(candidate)
+            try:
+                return int(float(candidate))
+            except ValueError:
+                return None
+        return None
+
+    session_tensor = None
+    if session_attr is not None:
+        session_values = session_attr
+        if isinstance(session_attr, str):
+            session_values = _fetch_store_attr(data['bill_version'], session_attr)
+        session_tensor = _to_tensor(session_values, length=num_bills)
+        if session_tensor is None:
+            raise ValueError(
+                f"Session attribute '{session_attr}' could not be resolved to a tensor."
+            )
+        if torch.is_floating_point(session_tensor):
+            session_tensor = session_tensor.round().long()
+        else:
+            session_tensor = session_tensor.to(torch.long)
+
+    yes_votes = torch.zeros(num_bills, dtype=torch.float32, device=device)
+    no_votes = torch.zeros(num_bills, dtype=torch.float32, device=device)
+    abstain_votes = torch.zeros(num_bills, dtype=torch.float32, device=device)
 
     yes_votes.index_add_(0, tgt_nodes, (vote_signal > 0).float())
     no_votes.index_add_(0, tgt_nodes, (vote_signal < 0).float())
+    abstain_votes.index_add_(0, tgt_nodes, (vote_signal == 0).float())
 
-    total_votes = yes_votes + no_votes + 1e-6
+    observed_total = yes_votes + no_votes + abstain_votes
 
-    yes_ratio = yes_votes / total_votes
-    no_ratio = no_votes / total_votes
+    candidate_attrs = []
+    if total_possible_attr is not None:
+        candidate_attrs.append(total_possible_attr)
+    candidate_attrs.extend(
+        [
+            'total_possible_votes',
+            'possible_votes',
+            'committee_size',
+            'chamber_size',
+            'membership_size',
+        ]
+    )
 
-    controversy = 4 * yes_ratio * no_ratio
+    total_possible = None
+    for attr in candidate_attrs:
+        value = None
+        if isinstance(attr, dict):
+            if session_tensor is None:
+                raise ValueError(
+                    "Session information is required when total_possible_attr is a mapping."
+                )
+            mapped = torch.zeros(num_bills, dtype=torch.float32, device=device)
+            for key, item in attr.items():
+                normalized_key = _normalize_session_key(key)
+                if normalized_key is None:
+                    continue
+                mask = session_tensor == normalized_key
+                if not torch.any(mask):
+                    continue
+                fill_tensor = _to_tensor(item, length=None)
+                if fill_tensor is None:
+                    continue
+                if fill_tensor.numel() == 1:
+                    mapped[mask] = fill_tensor.item()
+                elif fill_tensor.numel() == mask.sum().item():
+                    mapped[mask] = fill_tensor.to(device=device, dtype=torch.float32)
+                else:
+                    raise ValueError(
+                        "Mapping for total_possible_attr must provide either a scalar or "
+                        "a tensor matching the number of bills in the session."
+                    )
+            value = mapped
+        elif isinstance(attr, (str, torch.Tensor, np.ndarray, list, tuple, int, float)):
+            if isinstance(attr, str):
+                value = _fetch_store_attr(data['bill_version'], attr)
+            else:
+                value = attr
+        if value is None:
+            continue
+        total_possible = _to_tensor(value, length=num_bills)
+        if total_possible is not None:
+            break
+
+    if total_possible is None:
+        total_possible = observed_total.clone()
+
+    total_possible = torch.maximum(total_possible, observed_total)
+    total_possible = total_possible.clamp(min=1.0)
+
+    yes_ratio = yes_votes / total_possible
+    no_ratio = no_votes / total_possible
+    abstain_ratio = abstain_votes / total_possible
+    participation_ratio = (yes_votes + no_votes) / total_possible
+
+    controversy = 4 * yes_ratio * no_ratio * participation_ratio
     controversy = controversy.clamp(0, 1)
+
     data['bill_version'].controversy = controversy
+    data['bill_version'].yes_votes = yes_votes
+    data['bill_version'].no_votes = no_votes
+    data['bill_version'].abstain_votes = abstain_votes
+    data['bill_version'].total_possible_votes = total_possible
+    data['bill_version'].participation_ratio = participation_ratio
+    data['bill_version'].abstain_ratio = abstain_ratio
+
+    if session_tensor is not None:
+        unique_sessions, inverse = torch.unique(session_tensor, return_inverse=True)
+        session_yes = torch.zeros(unique_sessions.size(0), dtype=torch.float32, device=device)
+        session_no = torch.zeros_like(session_yes)
+        session_abstain = torch.zeros_like(session_yes)
+        session_total = torch.zeros_like(session_yes)
+
+        session_yes.index_add_(0, inverse, yes_votes)
+        session_no.index_add_(0, inverse, no_votes)
+        session_abstain.index_add_(0, inverse, abstain_votes)
+        session_total.index_add_(0, inverse, total_possible)
+
+        session_total = session_total.clamp(min=1.0)
+        session_yes_ratio = session_yes / session_total
+        session_no_ratio = session_no / session_total
+        session_participation = (session_yes + session_no) / session_total
+
+        session_controversy = 4 * session_yes_ratio * session_no_ratio * session_participation
+        session_controversy = session_controversy.clamp(0, 1)
+
+        def _session_key(value):
+            scalar = value.item()
+            if isinstance(scalar, float) and scalar.is_integer():
+                return int(scalar)
+            return scalar
+
+        data['bill_version'].session_controversy = {
+            _session_key(sess.cpu()): float(session_controversy[i].item())
+            for i, sess in enumerate(unique_sessions)
+        }
+        data['bill_version'].session_participation = {
+            _session_key(sess.cpu()): float(session_participation[i].item())
+            for i, sess in enumerate(unique_sessions)
+        }
 
     return data
 
-def load_and_preprocess_data(path='data3.pt'):
+def load_and_preprocess_data(path='data3.pt', controversy_kwargs=None):
     full_data = torch.load(path, weights_only=False)
     for nt in full_data.node_types:
         if hasattr(full_data[nt], 'x') and full_data[nt].x is not None:
@@ -209,7 +401,8 @@ def load_and_preprocess_data(path='data3.pt'):
     del full_data
     gc.collect()
     data = RemoveIsolatedNodes()(data)
-    data = compute_controversiality(clean_features(data))
+    kwargs = controversy_kwargs or {}
+    data = compute_controversiality(clean_features(data), **kwargs)
 
     for nt in data.node_types:
         ids = torch.arange(data[nt].num_nodes, device='mps')

--- a/tests/test_compute_controversiality.py
+++ b/tests/test_compute_controversiality.py
@@ -1,0 +1,67 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric.data")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from GNN.LeGNN import compute_controversiality
+
+
+def build_vote_data():
+    data = HeteroData()
+    data['legislator_term'].num_nodes = 3
+    data['bill_version'].num_nodes = 2
+    data['bill_version'].session = torch.tensor([2021, 2022])
+    data['bill_version'].total_possible_votes = torch.tensor([5.0, 4.0])
+
+    edge_index = torch.tensor([
+        [0, 1, 2, 0, 1],
+        [0, 0, 0, 1, 1],
+    ])
+    vote_signal = torch.tensor([1.0, -1.0, 0.0, 1.0, -1.0]).unsqueeze(1)
+
+    data['legislator_term', 'voted_on', 'bill_version'].edge_index = edge_index
+    data['legislator_term', 'voted_on', 'bill_version'].edge_attr = vote_signal
+    return data
+
+
+def test_compute_controversiality_accounts_for_abstentions():
+    data = HeteroData()
+    data['legislator_term'].num_nodes = 3
+    data['bill_version'].num_nodes = 1
+
+    edge_index = torch.tensor([
+        [0, 1, 2],
+        [0, 0, 0],
+    ])
+    vote_signal = torch.tensor([1.0, -1.0, 0.0]).unsqueeze(1)
+
+    data['legislator_term', 'voted_on', 'bill_version'].edge_index = edge_index
+    data['legislator_term', 'voted_on', 'bill_version'].edge_attr = vote_signal
+
+    result = compute_controversiality(data)
+
+    assert torch.allclose(result['bill_version'].abstain_votes, torch.tensor([1.0]))
+    assert torch.allclose(result['bill_version'].total_possible_votes, torch.tensor([3.0]))
+
+    expected = torch.tensor([8.0 / 27.0])
+    assert torch.allclose(result['bill_version'].controversy, expected, atol=1e-6)
+
+
+def test_compute_controversiality_uses_total_possible_and_session():
+    data = build_vote_data()
+
+    result = compute_controversiality(
+        data,
+        session_attr='session',
+        total_possible_attr='total_possible_votes',
+    )
+
+    expected = torch.tensor([0.064, 0.125])
+    assert torch.allclose(result['bill_version'].controversy, expected, atol=1e-6)
+
+    session_stats = result['bill_version'].session_controversy
+    assert session_stats[2021] == pytest.approx(0.064)
+    assert session_stats[2022] == pytest.approx(0.125)


### PR DESCRIPTION
## Summary
- update the controversy computation to include abstentions, support optional session-based aggregation, and use the total possible votes for normalization
- expose the additional controversy parameters through the preprocessing helper so callers can configure session and membership data
- add unit tests that validate abstention handling and session-aware normalization, skipping automatically when torch dependencies are unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c866785f908324a4fbb4b951718a0e