### PR TITLE
Implement modular Shiny dashboard for precomputed insights

### DIFF
--- a/shiny-app/R/globals.R
+++ b/shiny-app/R/globals.R
@@ -1,0 +1,42 @@
+# Global constants and shared lists -----------------------------------------------------
+
+APP_TITLE <- "California Legislative Insights"
+DATA_DIR <- "data/precomputed"
+GEO_DIR <- file.path(DATA_DIR, "geo")
+TOPIC_ALL_LABEL <- "All topics"
+DEFAULT_TERM <- NULL
+SEARCH_DEBOUNCE_MS <- 300
+
+MAP_METRIC_LABELS <- c(
+  Donations = "total_donations",
+  Lobbying = "total_lobbying",
+  Received = "total_received"
+)
+
+COUNTY_GEOJSON <- file.path(DATA_DIR, "counties.geojson")
+
+# Helper to build dataset paths ---------------------------------------------------------
+
+precomputed_path <- function(filename) {
+  file.path(DATA_DIR, filename)
+}
+
+# ensure required packages are available when app starts --------------------------------
+
+required_packages <- c(
+  "shiny", "bslib", "arrow", "DT", "leaflet", "plotly",
+  "sf", "dplyr", "tidyr", "purrr", "stringr", "readr", "jsonlite", "memoise",
+  "scales", "tidyselect"
+)
+
+#' Validate that all required packages are installed.
+check_required_packages <- function() {
+  missing <- required_packages[!vapply(required_packages, requireNamespace, logical(1), quietly = TRUE)]
+  if (length(missing) > 0) {
+    stop(
+      sprintf("Missing required packages: %s", paste(missing, collapse = ", ")),
+      call. = FALSE
+    )
+  }
+  invisible(TRUE)
+}

--- a/shiny-app/R/load_data.R
+++ b/shiny-app/R/load_data.R
@@ -1,0 +1,328 @@
+# Data loading helpers ------------------------------------------------------------------
+
+check_required_packages()
+
+library(dplyr)
+
+ensure_columns <- function(data, required, dataset) {
+  missing <- setdiff(required, names(data))
+  if (length(missing)) {
+    stop(sprintf("Dataset %s is missing required columns: %s", dataset, paste(missing, collapse = ", ")))
+  }
+  invisible(data)
+}
+
+read_parquet_tbl <- function(path, col_select = NULL) {
+  if (!file.exists(path)) {
+    stop(sprintf("Precomputed dataset not found: %s", path))
+  }
+  if (is.null(col_select)) {
+    arrow::read_parquet(path) |> tibble::as_tibble()
+  } else {
+    arrow::read_parquet(path, col_select = tidyselect::any_of(col_select)) |> tibble::as_tibble()
+  }
+}
+
+# Overview counts -----------------------------------------------------------------------
+
+.overview_counts <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("overview_counts.parquet"),
+    col_select = c("term", "n_bills", "n_committees", "n_legislators", "n_donors", "n_lobby_firms")
+  ) |> ensure_columns(
+    c("term", "n_bills", "n_committees", "n_legislators", "n_donors", "n_lobby_firms"),
+    "overview_counts"
+  )
+})
+
+get_overview_counts <- function(term) {
+  .overview_counts() |> filter(.data$term == term)
+}
+
+get_available_terms <- memoise::memoise(function() {
+  .overview_counts() |> arrange(desc(.data$term)) |> pull(.data$term) |> unique()
+})
+
+# Geography ----------------------------------------------------------------------------
+
+.county_shapes <- memoise::memoise(function() {
+  if (!file.exists(COUNTY_GEOJSON)) {
+    stop(sprintf("Missing county geometry file: %s", COUNTY_GEOJSON))
+  }
+  sf::st_read(COUNTY_GEOJSON, quiet = TRUE) |>
+    dplyr::select("county_id", "county_name", "geometry")
+})
+
+get_county_shapes <- function() {
+  .county_shapes()
+}
+
+.map_metrics <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("map_choropleth_by_term.parquet"),
+    col_select = c("term", "county_id", "metric", "value")
+  ) |> ensure_columns(c("term", "county_id", "metric", "value"), "map_choropleth_by_term")
+})
+
+get_map_metric <- function(term, metric_key) {
+  .map_metrics() |>
+    filter(.data$term == term, .data$metric == metric_key)
+}
+
+.county_financials <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("county_funding_by_term.parquet"),
+    col_select = c("term", "county_id", "total_donations", "total_lobbying", "total_received")
+  ) |> ensure_columns(
+    c("term", "county_id", "total_donations", "total_lobbying", "total_received"),
+    "county_funding_by_term"
+  )
+})
+
+get_county_financials <- function(county_id) {
+  .county_financials() |>
+    filter(.data$county_id == county_id)
+}
+
+.geo_spread_entities <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("geo_spread_entities.parquet"),
+    col_select = c("term", "entity_type", "entity_name", "total", "county_entropy", "n_counties_active")
+  ) |> ensure_columns(
+    c("term", "entity_type", "entity_name", "total", "county_entropy", "n_counties_active"),
+    "geo_spread_entities"
+  )
+})
+
+get_geo_spread_entities <- function(term, entity_type = NULL) {
+  df <- .geo_spread_entities() |> filter(.data$term == term)
+  if (!is.null(entity_type)) {
+    df <- df |> filter(.data$entity_type == entity_type)
+  }
+  df
+}
+
+# Topics ---------------------------------------------------------------------------------
+
+.topic_division <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("topic_division_time.parquet"),
+    col_select = c(
+      "topic", "term", "mean_polarization", "party_line_share", "dem_yes_rate",
+      "rep_yes_rate", "n_rollcalls", "controversiality", "momentum"
+    )
+  )
+})
+
+get_topic_summary <- function(min_rollcalls = 0, topic = NULL) {
+  df <- .topic_division()
+  if (min_rollcalls > 0) {
+    df <- df |> filter(.data$n_rollcalls >= min_rollcalls)
+  }
+  if (!is.null(topic)) {
+    df <- df |> filter(.data$topic == topic)
+  }
+  df
+}
+
+.topic_funding <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("topic_funding_by_term.parquet"),
+    col_select = c("topic", "term", "total_donations", "total_lobbying", "total_received")
+  )
+})
+
+get_topic_funding <- function(topic) {
+  .topic_funding() |> filter(.data$topic == topic)
+}
+
+get_all_topic_funding <- function() {
+  .topic_funding()
+}
+
+.topic_example_bills <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("bills_table.parquet"),
+    col_select = c(
+      "bill_ID", "bill_id_raw", "title", "topic", "term", "First_action",
+      "longevity_days", "n_versions", "median_sim", "outcome", "vote_signal",
+      "route_key"
+    )
+  )
+})
+
+get_topic_example_bills <- function(topic, term = NULL) {
+  df <- .topic_example_bills() |> filter(.data$topic == topic)
+  if (!is.null(term)) {
+    df <- df |> filter(.data$term == term)
+  }
+  df
+}
+
+# People ---------------------------------------------------------------------------------
+
+.committee_metrics <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("committee_gatekeeping.parquet"),
+    col_select = c("committee", "term", "gatekeeping")
+  ) |> left_join(
+    read_parquet_tbl(
+      precomputed_path("committee_workload_median.parquet"),
+      col_select = c("committee", "term", "median_weekly_bills")
+    ),
+    by = c("committee", "term")
+  )
+})
+
+get_committee_metrics <- function(term) {
+  .committee_metrics() |> filter(.data$term == term)
+}
+
+.actor_overall <- memoise::memoise(function() {
+  path <- precomputed_path("actor_overall.parquet")
+  if (!file.exists(path)) return(tibble::tibble())
+  read_parquet_tbl(path)
+})
+
+get_actor_overall <- function(term) {
+  df <- .actor_overall()
+  if (!nrow(df)) return(df)
+  if ("term" %in% names(df)) {
+    df <- df |> filter(.data$term == term)
+  }
+  df
+}
+
+.actor_topic <- memoise::memoise(function() {
+  path <- precomputed_path("actor_topic.parquet")
+  if (!file.exists(path)) return(tibble::tibble())
+  read_parquet_tbl(path)
+})
+
+get_actor_topic <- function(term, topic = NULL) {
+  df <- .actor_topic()
+  if (!nrow(df)) return(df)
+  if ("term" %in% names(df)) {
+    df <- df |> filter(.data$term == term)
+  }
+  if (!is.null(topic) && topic != TOPIC_ALL_LABEL) {
+    df <- df |> filter(.data$topic == topic)
+  }
+  df
+}
+
+# Donors ---------------------------------------------------------------------------------
+
+.entity_stance <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("entity_stance_by_term.parquet"),
+    col_select = c("term", "entity_type", "entity_name", "stance_score", "lean", "total")
+  )
+})
+
+get_entity_stance <- function(term, entity_type = NULL) {
+  df <- .entity_stance() |> filter(.data$term == term)
+  if (!is.null(entity_type)) {
+    df <- df |> filter(.data$entity_type == entity_type)
+  }
+  df
+}
+
+.donor_topic <- memoise::memoise(function() {
+  path <- precomputed_path("donor_topic_by_term.parquet")
+  if (!file.exists(path)) return(tibble::tibble())
+  read_parquet_tbl(path)
+})
+
+get_donor_topic_allocations <- function(term, entity_name) {
+  df <- .donor_topic()
+  if (!nrow(df)) return(df)
+  name_col <- intersect(c("entity_name", "ExpenderName"), names(df))[1]
+  if (is.na(name_col)) {
+    return(tibble::tibble())
+  }
+  df |> filter(.data$term == term, .data[[name_col]] == entity_name)
+}
+
+# Bills ----------------------------------------------------------------------------------
+
+.pipeline_funnel <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("pipeline_stage_funnel.parquet"),
+    col_select = c("term", "topic", "from", "to", "entered", "advanced", "pass_rate", "median_days")
+  )
+})
+
+get_pipeline_funnel <- function(term, topic = NULL) {
+  df <- .pipeline_funnel() |> filter(.data$term == term)
+  if (!is.null(topic) && topic != TOPIC_ALL_LABEL) {
+    df <- df |> filter(.data$topic == topic)
+  }
+  df
+}
+
+.route_archetypes <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("route_archetypes.parquet"),
+    col_select = c("term", "topic", "route_key", "n", "pass_rate")
+  )
+})
+
+get_route_archetypes <- function(term, topic = NULL) {
+  df <- .route_archetypes() |> filter(.data$term == term)
+  if (!is.null(topic) && topic != TOPIC_ALL_LABEL) {
+    df <- df |> filter(.data$topic == topic)
+  }
+  df
+}
+
+.survival_curves <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("survival_curves.parquet"),
+    col_select = c("term", "topic", "t", "survival")
+  )
+})
+
+get_survival_curves <- function(term, topic = NULL) {
+  df <- .survival_curves() |> filter(.data$term == term)
+  if (!is.null(topic) && topic != TOPIC_ALL_LABEL) {
+    df <- df |> filter(.data$topic == topic)
+  }
+  df
+}
+
+.bills_table <- memoise::memoise(function() {
+  read_parquet_tbl(
+    precomputed_path("bills_table.parquet"),
+    col_select = c(
+      "bill_ID", "bill_id_raw", "title", "topic", "term", "First_action",
+      "longevity_days", "n_versions", "median_sim", "outcome", "vote_signal"
+    )
+  )
+})
+
+get_bills_table <- function(term, topic = NULL, outcome = NULL, route_key = NULL) {
+  df <- .bills_table() |> filter(.data$term == term)
+  if (!is.null(topic) && topic != TOPIC_ALL_LABEL) {
+    df <- df |> filter(.data$topic == topic)
+  }
+  if (!is.null(outcome) && outcome != "All") {
+    df <- df |> filter(.data$outcome == outcome)
+  }
+  if (!is.null(route_key) && nchar(route_key) && "route_key" %in% names(df)) {
+    df <- df |> filter(.data$route_key == route_key)
+  }
+  df
+}
+
+.per_bill_model <- memoise::memoise(function() {
+  path <- precomputed_path("per_bill.parquet")
+  if (!file.exists(path)) return(tibble::tibble())
+  read_parquet_tbl(path)
+})
+
+get_per_bill_model <- function(bill_id) {
+  df <- .per_bill_model()
+  if (!nrow(df)) return(df)
+  df |> filter(.data$bill_ID == bill_id)
+}

--- a/shiny-app/R/modules/mod_bills.R
+++ b/shiny-app/R/modules/mod_bills.R
@@ -1,0 +1,181 @@
+mod_bills_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    bslib::card(
+      bslib::card_body(
+        shiny::selectInput(ns("outcome_filter"), "Outcome", choices = c("All", "Passed", "Failed"), selected = "All", width = "200px"),
+        shiny::selectizeInput(ns("route_key_filter"), "Route archetype", choices = NULL, multiple = FALSE, options = list(placeholder = "All routes"), width = "300px")
+      )
+    ),
+    bslib::layout_columns(
+      col_widths = c(7, 5),
+      bslib::card(
+        bslib::card_header("Bill pipeline"),
+        bslib::card_body(plotly::plotlyOutput(ns("funnel"), height = 360))
+      ),
+      bslib::card(
+        bslib::card_header("How to read this"),
+        bslib::card_body(p("Each stage shows how many bills entered and advanced. Use the filters to focus on a topic, route, or outcome."))
+      )
+    ),
+    bslib::layout_columns(
+      col_widths = c(6, 6),
+      bslib::card(
+        bslib::card_header("Route archetypes"),
+        bslib::card_body(DT::DTOutput(ns("routes")))
+      ),
+      bslib::card(
+        bslib::card_header("Survival curve"),
+        bslib::card_body(plotly::plotlyOutput(ns("survival"), height = 320))
+      )
+    ),
+    bslib::card(
+      bslib::card_header("Bills in motion"),
+      bslib::card_body(DT::DTOutput(ns("bills_table")))
+    ),
+    shiny::uiOutput(ns("why_panel"))
+  )
+}
+
+mod_bills_server <- function(id, term, topic, search) {
+  moduleServer(id, function(input, output, session) {
+    selected_route <- shiny::reactiveVal(NULL)
+    selected_bill <- shiny::reactiveVal(NULL)
+
+    funnel_data <- shiny::reactive({
+      req(term())
+      get_pipeline_funnel(term(), topic())
+    }) |>
+      shiny::bindCache(term(), topic())
+
+    route_data <- shiny::reactive({
+      req(term())
+      get_route_archetypes(term(), topic())
+    }) |>
+      shiny::bindCache(term(), topic())
+
+    observe({
+      routes <- route_data()
+      choices <- c("All", sort(unique(routes$route_key)))
+      shiny::updateSelectizeInput(session, "route_key_filter", choices = choices, selected = "All")
+    })
+
+    survival_data <- shiny::reactive({
+      req(term())
+      get_survival_curves(term(), topic())
+    }) |>
+      shiny::bindCache(term(), topic())
+
+    output$funnel <- plotly::renderPlotly({
+      df <- funnel_data()
+      if (!nrow(df)) return(plotly::plotly_empty())
+      stage_levels <- unique(c(df$from, tail(df$to, 1)))
+      df$entered_label <- paste(df$from, "entered")
+      plotly::plot_ly(df, x = ~from, y = ~entered, type = "bar", name = "Entered") |>
+        plotly::add_trace(y = ~advanced, name = "Advanced") |>
+        plotly::layout(barmode = "group", xaxis = list(title = "Stage"), yaxis = list(title = "Count"))
+    })
+
+    output$routes <- DT::renderDT({
+      df <- route_data()
+      if (!nrow(df)) {
+        return(DT::datatable(tibble::tibble(message = "No route archetypes available.")))
+      }
+      DT::datatable(
+        df,
+        filter = "top",
+        selection = "single",
+        extensions = "Buttons",
+        options = list(pageLength = 10, dom = "Bfrtip", buttons = c("copy", "csv"))
+      )
+    })
+
+    observeEvent(input$routes_rows_selected, {
+      df <- route_data()
+      idx <- input$routes_rows_selected
+      if (length(idx) == 1 && idx <= nrow(df)) {
+        selected_route(df$route_key[idx])
+        shiny::updateSelectizeInput(session, "route_key_filter", selected = df$route_key[idx])
+      }
+    })
+
+    observeEvent(input$route_key_filter, {
+      value <- input$route_key_filter
+      if (is.null(value) || value == "All") {
+        selected_route(NULL)
+      } else {
+        selected_route(value)
+      }
+    })
+
+    output$survival <- plotly::renderPlotly({
+      df <- survival_data()
+      if (!nrow(df)) return(plotly::plotly_empty())
+      plotly::plot_ly(df, x = ~t, y = ~survival, color = ~topic, type = "scatter", mode = "lines") |>
+        plotly::layout(xaxis = list(title = "Days"), yaxis = list(title = "Survival probability"), legend = list(orientation = "h"))
+    })
+
+    bills_data <- shiny::reactive({
+      req(term())
+      get_bills_table(term(), topic(), input$outcome_filter, selected_route())
+    }) |>
+      shiny::bindCache(term(), topic(), input$outcome_filter, selected_route())
+
+    output$bills_table <- DT::renderDT({
+      df <- bills_data()
+      if (!nrow(df)) {
+        return(DT::datatable(tibble::tibble(message = "No bills found for this view.")))
+      }
+      if (!"bill_link" %in% names(df) && "bill_ID" %in% names(df)) {
+        df$bill_link <- sprintf('<a href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=%s" target="_blank">view</a>', df$bill_ID)
+      }
+      DT::datatable(
+        df,
+        filter = "top",
+        selection = "single",
+        escape = FALSE,
+        extensions = "Buttons",
+        options = list(pageLength = 20, dom = "Bfrtip", buttons = c("copy", "csv"))
+      )
+    })
+
+    bills_proxy <- DT::dataTableProxy("bills_table")
+    observeEvent(search(), {
+      DT::updateSearch(bills_proxy, keywords = list(global = search()))
+    })
+
+    observeEvent(input$bills_table_rows_selected, {
+      df <- bills_data()
+      idx <- input$bills_table_rows_selected
+      if (length(idx) == 1 && idx <= nrow(df)) {
+        selected_bill(df$bill_ID[idx])
+      }
+    })
+
+    output$why_panel <- shiny::renderUI({
+      bill_id <- selected_bill()
+      if (is.null(bill_id)) return(NULL)
+      model <- get_per_bill_model(bill_id)
+      if (!nrow(model)) {
+        return(bslib::card(bslib::card_body(sprintf("No model explanation available for %s", bill_id))))
+      }
+      info <- model[1, ]
+      bottlenecks <- if ("committee_bottlenecks" %in% names(info)) jsonlite::fromJSON(info$committee_bottlenecks) else NULL
+      pivotal <- if ("pivotal_actors" %in% names(info)) jsonlite::fromJSON(info$pivotal_actors) else NULL
+      bslib::card(
+        bslib::card_header(sprintf("Why this bill moves: %s", bill_id)),
+        bslib::card_body(
+          if (!is.null(info$p_pass_total)) htmltools::tags$p(sprintf("Estimated pass probability: %.1f%%", info$p_pass_total * 100)),
+          if (!is.null(bottlenecks)) htmltools::tags$div(
+            htmltools::tags$h6("Committee bottlenecks"),
+            htmltools::tags$ul(purrr::map(bottlenecks, htmltools::tags$li))
+          ),
+          if (!is.null(pivotal)) htmltools::tags$div(
+            htmltools::tags$h6("Pivotal actors"),
+            htmltools::tags$ul(purrr::map(pivotal, htmltools::tags$li))
+          )
+        )
+      )
+    })
+  })
+}

--- a/shiny-app/R/modules/mod_donors.R
+++ b/shiny-app/R/modules/mod_donors.R
@@ -1,0 +1,186 @@
+mod_donors_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    div(class = "mb-3", "Explore donors and lobby firms by stance, geographic spread, and total influence."),
+    bslib::card(
+      bslib::card_body(
+        shiny::radioButtons(ns("entity_type"), "Entity type", choices = c("Donor", "Lobby firm"), inline = TRUE),
+        shiny::selectizeInput(ns("entity_search"), "Focus on entity", choices = NULL, options = list(placeholder = "Start typing a name"), multiple = FALSE)
+      )
+    ),
+    bslib::card(
+      bslib::card_header("Stance vs. geographic spread"),
+      bslib::card_body(
+        p("Horizontal axis shows how concentrated an entity is geographically (left = concentrated). Vertical axis shows stance score. Circle size scales with totals; color reflects lean."),
+        plotly::plotlyOutput(ns("entity_scatter"), height = 420)
+      )
+    ),
+    bslib::layout_columns(
+      col_widths = c(6, 6),
+      bslib::card(
+        bslib::card_header("Entity list"),
+        bslib::card_body(DT::DTOutput(ns("entity_table")))
+      ),
+      bslib::card(
+        bslib::card_header("Entity detail"),
+        bslib::card_body(
+          leaflet::leafletOutput(ns("entity_map"), height = 320),
+          plotly::plotlyOutput(ns("entity_topics"), height = 220)
+        )
+      )
+    )
+  )
+}
+
+mod_donors_server <- function(id, term, topic, search) {
+  moduleServer(id, function(input, output, session) {
+    selected_entity <- shiny::reactiveVal(NULL)
+
+    entity_data <- shiny::reactive({
+      req(term())
+      stance <- get_entity_stance(term())
+      if (!nrow(stance)) return(tibble::tibble())
+      spread <- get_geo_spread_entities(term())
+      df <- dplyr::left_join(stance, spread, by = c("term", "entity_type", "entity_name", "total"))
+      df
+    }) |>
+      shiny::bindCache(term())
+
+    observe({
+      df <- entity_data()
+      if (!nrow(df)) return(NULL)
+      shiny::updateSelectizeInput(session, "entity_search", choices = sort(unique(df$entity_name)), server = TRUE)
+    })
+
+    filtered_entities <- shiny::reactive({
+      df <- entity_data()
+      if (!nrow(df)) return(df)
+      df <- df |> dplyr::filter(.data$entity_type == input$entity_type)
+      if (!is.null(topic()) && topic() != TOPIC_ALL_LABEL && "topic" %in% names(df)) {
+        df <- df |> dplyr::filter(.data$topic == topic())
+      }
+      df
+    }) |>
+      shiny::bindCache(term(), input$entity_type, topic())
+
+    observeEvent(input$entity_search, {
+      name <- input$entity_search
+      if (!nzchar(name)) return()
+      df <- filtered_entities()
+      ent <- df |> dplyr::filter(.data$entity_name == name)
+      if (nrow(ent)) selected_entity(ent[1, , drop = FALSE])
+    })
+
+    output$entity_scatter <- plotly::renderPlotly({
+      df <- filtered_entities()
+      if (!nrow(df)) return(plotly::plotly_empty())
+      df$size <- sqrt(df$total)
+      df$color <- safe_pull(df, "lean", "Neutral")
+      plotly::plot_ly(
+        df,
+        x = ~1 / pmax(1, safe_pull(df, "n_counties_active", 1)),
+        y = ~stance_score,
+        type = "scatter",
+        mode = "markers",
+        text = ~paste0(entity_name, "\nTotal: ", fmt_money(total), "\nEntropy: ", round(safe_pull(df, "county_entropy", NA_real_), 2)),
+        hoverinfo = "text",
+        color = ~color,
+        size = ~size,
+        sizes = c(10, 60),
+        customdata = ~entity_name,
+        source = session$ns("entity_scatter")
+      ) |>
+        plotly::layout(
+          xaxis = list(title = "Geographic concentration (left = concentrated)", showticklabels = FALSE),
+          yaxis = list(title = "Stance score"),
+          showlegend = FALSE
+        )
+    })
+
+    observeEvent(plotly::event_data("plotly_click", source = session$ns("entity_scatter")), {
+      click <- plotly::event_data("plotly_click", source = session$ns("entity_scatter"))
+      if (is.null(click)) return()
+      name <- click$customdata
+      df <- filtered_entities()
+      if (!is.null(name) && name %in% df$entity_name) {
+        selected_entity(df |> dplyr::filter(.data$entity_name == name) |> dplyr::slice_head(n = 1))
+      }
+    })
+
+    output$entity_table <- DT::renderDT({
+      df <- filtered_entities()
+      if (!nrow(df)) {
+        return(DT::datatable(tibble::tibble(message = "No entities available for this view.")))
+      }
+      display <- df |> dplyr::select(dplyr::any_of(c("entity_name", "stance_score", "lean", "total", "county_entropy", "n_counties_active")))
+      DT::datatable(
+        display,
+        filter = "top",
+        selection = "single",
+        extensions = "Buttons",
+        options = list(pageLength = 15, dom = "Bfrtip", buttons = c("copy", "csv"))
+      )
+    })
+
+    proxy <- DT::dataTableProxy("entity_table")
+    observeEvent(search(), {
+      DT::updateSearch(proxy, keywords = list(global = search()))
+    })
+
+    observeEvent(input$entity_table_rows_selected, {
+      df <- filtered_entities()
+      idx <- input$entity_table_rows_selected
+      if (length(idx) == 1 && idx <= nrow(df)) {
+        selected_entity(df[idx, , drop = FALSE])
+      }
+    })
+
+    parse_share_column <- function(entity_row) {
+      if (!"share_by_county" %in% names(entity_row)) return(NULL)
+      val <- entity_row$share_by_county[[1]]
+      if (is.null(val)) return(NULL)
+      if (is.character(val)) {
+        val <- tryCatch(jsonlite::fromJSON(val), error = function(e) NULL)
+      }
+      if (is.null(val)) return(NULL)
+      tibble::as_tibble(val)
+    }
+
+    output$entity_map <- leaflet::renderLeaflet({
+      ent <- selected_entity()
+      if (is.null(ent)) {
+        return(leaflet::leaflet() |> leaflet::addProviderTiles(leaflet::providers$CartoDB.Positron))
+      }
+      shares <- parse_share_column(ent)
+      if (is.null(shares) || !all(c("county_id", "share") %in% names(shares))) {
+        return(leaflet::leaflet() |> leaflet::addProviderTiles(leaflet::providers$CartoDB.Positron) |>
+                 leaflet::addControl("County-level allocations not available.", position = "topright"))
+      }
+      shapes <- get_county_shapes()
+      df <- dplyr::left_join(shapes, shares, by = "county_id")
+      pal <- leaflet::colorBin(pal_sequential(7), domain = df$share, bins = 7, na.color = "#f5f5f5")
+      leaflet::leaflet(df) |>
+        leaflet::addProviderTiles(leaflet::providers$CartoDB.Positron) |>
+        leaflet::addPolygons(
+          fillColor = ~pal(share),
+          color = "#ffffff",
+          weight = 0.6,
+          opacity = 0.8,
+          fillOpacity = 0.8,
+          label = ~sprintf("%s: %.1f%%", county_name, share * 100)
+        )
+    })
+
+    output$entity_topics <- plotly::renderPlotly({
+      ent <- selected_entity()
+      if (is.null(ent)) return(plotly::plotly_empty())
+      df <- get_donor_topic_allocations(term(), ent$entity_name)
+      if (!nrow(df)) {
+        return(plotly::plotly_empty())
+      }
+      df$value <- safe_pull(df, "donations_allocated", safe_pull(df, "total", NA_real_))
+      plotly::plot_ly(df, x = ~topic, y = ~value, type = "bar") |>
+        plotly::layout(xaxis = list(title = "Topic"), yaxis = list(title = "Allocated"))
+    })
+  })
+}

--- a/shiny-app/R/modules/mod_header.R
+++ b/shiny-app/R/modules/mod_header.R
@@ -1,0 +1,85 @@
+mod_header_ui <- function(id, terms, topics) {
+  ns <- NS(id)
+  term_choices <- setNames(terms, terms)
+  topic_choices <- c(TOPIC_ALL_LABEL, sort(unique(topics)))
+  tagList(
+    span(class = "app-title", APP_TITLE),
+    bslib::nav_spacer(),
+    div(
+      class = "header-controls d-flex align-items-center gap-2",
+      shiny::selectInput(
+        inputId = ns("term"),
+        label = shiny::span(class = "visually-hidden", "Select term"),
+        choices = term_choices,
+        selected = term_choices[1],
+        width = "140px"
+      ),
+      shiny::selectizeInput(
+        inputId = ns("topic"),
+        label = shiny::span(class = "visually-hidden", "Filter by topic"),
+        choices = topic_choices,
+        selected = TOPIC_ALL_LABEL,
+        options = list(placeholder = "All topics", plugins = list("remove_button")),
+        width = "220px"
+      ),
+      shiny::textInput(
+        inputId = ns("search"),
+        label = shiny::span(class = "visually-hidden", "Search"),
+        placeholder = "Search tables",
+        width = "200px"
+      ),
+      shiny::actionButton(ns("copy_link"), label = NULL, icon = shiny::icon("link"), title = "Copy link to this view"),
+      bslib::toggle_dark_mode(id = ns("dark_toggle"), class = "ms-2")
+    )
+  )
+}
+
+mod_header_server <- function(id, default_term, on_state_change) {
+  moduleServer(id, function(input, output, session) {
+    term <- shiny::reactiveVal(default_term)
+    topic <- shiny::reactiveVal(TOPIC_ALL_LABEL)
+    search <- shiny::reactiveVal("")
+
+    observeEvent(input$term, {
+      term(input$term)
+      on_state_change()
+    }, ignoreNULL = FALSE)
+
+    observeEvent(input$topic, {
+      topic(input$topic)
+      on_state_change()
+    }, ignoreNULL = FALSE)
+
+    observeEvent(input$search, {
+      search(input$search)
+    }, ignoreNULL = FALSE)
+
+    observeEvent(input$copy_link, {
+      session$sendCustomMessage("copy-url", list(url = session$clientData$url_href))
+    })
+
+    list(
+      term = shiny::reactive(term()),
+      topic = shiny::reactive(topic()),
+      search = shiny::reactive(search()),
+      update_term = function(value) {
+        if (!is.null(value) && !identical(value, term())) {
+          shiny::updateSelectInput(session, "term", selected = value)
+          term(value)
+        }
+      },
+      update_topic = function(value) {
+        if (!is.null(value) && !identical(value, topic())) {
+          shiny::updateSelectizeInput(session, "topic", selected = value)
+          topic(value)
+        }
+      },
+      update_search = function(value) {
+        if (!is.null(value) && !identical(value, search())) {
+          shiny::updateTextInput(session, "search", value = value)
+          search(value)
+        }
+      }
+    )
+  })
+}

--- a/shiny-app/R/modules/mod_map.R
+++ b/shiny-app/R/modules/mod_map.R
@@ -1,0 +1,214 @@
+mod_map_ui <- function(id) {
+  ns <- NS(id)
+  bslib::layout_sidebar(
+    fillable = TRUE,
+    sidebar = bslib::card(
+      bslib::card_body(
+        shiny::selectInput(
+          ns("metric"),
+          "Funding metric",
+          choices = names(MAP_METRIC_LABELS),
+          selected = names(MAP_METRIC_LABELS)[1]
+        ),
+        shiny::selectizeInput(
+          ns("entity_search"),
+          "Highlight entity",
+          choices = NULL,
+          options = list(placeholder = "Search donor or lobby firm"),
+          multiple = FALSE
+        )
+      )
+    ),
+    bslib::card(
+      class = "map-card",
+      bslib::card_header("Money by county"),
+      bslib::card_body(
+        p("County shading shows the selected funding metric for the current term. Hover for rank and percentile; click a county to explore trends."),
+        leaflet::leafletOutput(ns("county_map"), height = 520)
+      )
+    ),
+    bslib::layout_columns(
+      col_widths = c(6, 6),
+      bslib::card(
+        bslib::card_header("County trend"),
+        bslib::card_body(plotly::plotlyOutput(ns("county_trends"), height = 320))
+      ),
+      bslib::card(
+        bslib::card_header("Top donors & lobby"),
+        bslib::card_body(DT::DTOutput(ns("top_actors")))
+      )
+    )
+  )
+}
+
+mod_map_server <- function(id, term, topic) {
+  moduleServer(id, function(input, output, session) {
+    shapes <- shiny::reactive(get_county_shapes())
+
+    observe({
+      req(term())
+      entities <- get_geo_spread_entities(term())
+      shiny::updateSelectizeInput(session, "entity_search", choices = sort(unique(entities$entity_name)), server = TRUE)
+    })
+
+    selected_county <- shiny::reactiveVal(NULL)
+
+    metric_key <- shiny::reactive({
+      MAP_METRIC_LABELS[[input$metric]]
+    })
+
+    parse_share_column <- function(x) {
+      if (is.null(x) || length(x) == 0) return(NULL)
+      entry <- x[[1]]
+      if (is.null(entry)) return(NULL)
+      if (is.character(entry)) {
+        parsed <- tryCatch(jsonlite::fromJSON(entry), error = function(e) NULL)
+      } else {
+        parsed <- entry
+      }
+      if (is.null(parsed)) return(NULL)
+      tibble::as_tibble(parsed)
+    }
+
+    entity_overlay <- shiny::reactive({
+      req(term())
+      name <- input$entity_search
+      if (is.null(name) || !nzchar(name)) return(NULL)
+      df <- get_geo_spread_entities(term())
+      ent <- df |> dplyr::filter(.data$entity_name == name)
+      if (!nrow(ent)) return(NULL)
+      shares <- NULL
+      if ("share_by_county" %in% names(ent)) {
+        shares <- parse_share_column(ent$share_by_county)
+      }
+      list(row = ent, shares = shares)
+    })
+
+    map_data <- shiny::reactive({
+      req(term(), metric_key())
+      metric_df <- get_map_metric(term(), metric_key())
+      geo <- shapes()
+      joined <- dplyr::left_join(geo, metric_df, by = "county_id")
+      stats <- rank_and_percentile(joined$value)
+      joined$rank <- stats$rank
+      joined$percentile <- stats$percentile
+      overlay <- entity_overlay()
+      if (!is.null(overlay) && !is.null(overlay$shares) && all(c("county_id", "share") %in% names(overlay$shares))) {
+        joined <- dplyr::left_join(joined, overlay$shares, by = "county_id")
+        joined$entity_share <- joined$share
+      } else {
+        joined$entity_share <- NA_real_
+      }
+      joined
+    }) |>
+      shiny::bindCache(term(), metric_key(), input$entity_search)
+
+    output$county_map <- leaflet::renderLeaflet({
+      leaflet::leaflet(options = leaflet::leafletOptions(preferCanvas = TRUE)) |>
+        leaflet::addProviderTiles(leaflet::providers$CartoDB.Positron) |>
+        leaflet::setView(lng = -119.5, lat = 37.25, zoom = 5.5)
+    })
+
+    observe({
+      req(map_data())
+      df <- map_data()
+      pal <- leaflet::colorBin(palette = pal_sequential(7), domain = df$value, bins = 7, na.color = "#f5f5f5")
+      proxy <- leaflet::leafletProxy("county_map", session = session, data = df)
+      proxy |>
+        leaflet::clearShapes() |>
+        leaflet::addPolygons(
+          fillColor = ~pal(value),
+          weight = 0.6,
+          color = "#ffffff",
+          opacity = 0.8,
+          fillOpacity = 0.8,
+          layerId = ~county_id,
+          highlightOptions = leaflet::highlightOptions(weight = 2, color = "#2B4C7E", bringToFront = TRUE),
+          label = ~sprintf(
+            "%s\n%s: %s\nRank: %s (%.0f%%)",
+            county_name,
+            input$metric,
+            fmt_money(value, digits = 1),
+            scales::comma(rank),
+            percentile * 100
+          ),
+          labelOptions = leaflet::labelOptions(direction = "auto")
+        )
+      overlay <- entity_overlay()
+      proxy |> leaflet::clearControls()
+      if (!is.null(overlay) && nrow(overlay$row)) {
+        ent <- overlay$row
+        html <- htmltools::tags$div(
+          class = "entity-overlay",
+          htmltools::tags$strong(ent$entity_name),
+          htmltools::tags$br(),
+          sprintf("Total: %s", fmt_money(ent$total)),
+          htmltools::tags$br(),
+          sprintf("County spread (entropy): %.2f", safe_pull(ent, "county_entropy", NA_real_))
+        )
+        proxy |> leaflet::addControl(html = htmltools::as.tags(html), position = "topright")
+      }
+    })
+
+    observeEvent(input$county_map_shape_click, {
+      click <- input$county_map_shape_click
+      if (!is.null(click$id)) {
+        selected_county(click$id)
+      }
+    })
+
+    county_timeseries <- shiny::reactive({
+      req(selected_county())
+      get_county_financials(selected_county())
+    }) |>
+      shiny::bindCache(selected_county())
+
+    output$county_trends <- plotly::renderPlotly({
+      df <- county_timeseries()
+      validate(need(nrow(df), "Select a county from the map."))
+      plotly::plot_ly(df, x = ~term, y = ~total_donations, type = "scatter", mode = "lines+markers", name = "Donations") |>
+        plotly::add_trace(y = ~total_lobbying, name = "Lobbying") |>
+        plotly::add_trace(y = ~total_received, name = "Received") |>
+        plotly::layout(xaxis = list(title = "Term"), yaxis = list(title = "USD"), legend = list(orientation = "h"))
+    })
+
+    top_actors_data <- shiny::reactive({
+      req(term())
+      geo_df <- get_geo_spread_entities(term())
+      county_id <- selected_county()
+      overlay <- entity_overlay()
+      if (!is.null(county_id) && !is.null(overlay) && !is.null(overlay$shares) && "county_id" %in% names(geo_df)) {
+        shares <- overlay$shares
+        if (all(c("county_id", "share") %in% names(shares))) {
+          shares <- shares |> dplyr::filter(.data$county_id == county_id)
+          geo_df <- geo_df |> dplyr::semi_join(shares, by = "county_id")
+        }
+      }
+      geo_df |> dplyr::arrange(dplyr::desc(.data$total)) |> dplyr::mutate(rank = dplyr::row_number())
+    }) |>
+      shiny::bindCache(term(), selected_county())
+
+    output$top_actors <- DT::renderDT({
+      df <- top_actors_data()
+      cols <- intersect(c("rank", "entity_name", "entity_type", "total", "county_share", "county_entropy"), names(df))
+      if (!length(cols)) {
+        return(DT::datatable(tibble::tibble(message = "No entity details available.")))
+      }
+      table <- df |> dplyr::select(dplyr::all_of(cols))
+      DT::datatable(
+        table,
+        filter = "top",
+        extensions = "Buttons",
+        options = list(pageLength = 15, dom = "Bfrtip", buttons = c("copy", "csv")),
+        caption = htmltools::tags$caption(
+          style = "caption-side: top; text-align: left;",
+          if (!is.null(selected_county())) {
+            "Top entities for the selected county"
+          } else {
+            "Top entities statewide"
+          }
+        )
+      )
+    })
+  })
+}

--- a/shiny-app/R/modules/mod_overview.R
+++ b/shiny-app/R/modules/mod_overview.R
@@ -1,0 +1,97 @@
+mod_overview_ui <- function(id) {
+  ns <- NS(id)
+  bslib::layout_columns(
+    col_widths = c(3, 3, 3, 3),
+    bslib::card(
+      class = "metric-card",
+      bslib::card_header("Bills in play"),
+      bslib::card_body(
+        shiny::uiOutput(ns("bills_value"), class = "metric-value"),
+        p("Number of active and archived bills captured in this legislative term."),
+        class = "d-flex flex-column gap-2"
+      )
+    ),
+    bslib::card(
+      class = "metric-card",
+      bslib::card_header("Committees"),
+      bslib::card_body(
+        shiny::uiOutput(ns("committees_value")),
+        p("Committee bodies with measurable gatekeeping or workload activity."),
+        class = "d-flex flex-column gap-2"
+      )
+    ),
+    bslib::card(
+      class = "metric-card",
+      bslib::card_header("Legislators"),
+      bslib::card_body(
+        shiny::uiOutput(ns("legislators_value")),
+        p("Individual lawmakers tracked for influence, voting behavior, and activity."),
+        class = "d-flex flex-column gap-2"
+      )
+    ),
+    bslib::card(
+      class = "metric-card",
+      bslib::card_header("Money movers"),
+      bslib::card_body(
+        shiny::uiOutput(ns("money_value")),
+        p("Distinct donors and lobby firms contributing funds or effort."),
+        class = "d-flex flex-column gap-2"
+      )
+    ),
+    bslib::card(
+      colspan = 6,
+      bslib::card_header("What's in this dashboard"),
+      bslib::card_body(
+        p("Track legislation, money flows, and actors shaping outcomes. Use the navigation tabs above to explore geography, topics, people, donors, and bill progress."),
+        class = "d-flex"
+      )
+    ),
+    bslib::card(
+      colspan = 6,
+      bslib::card_header("How to read the visuals"),
+      bslib::card_body(
+        p("Hover for details, use the global term/topic filters, and click rows or cards for deeper context. Tables are searchable and downloadable via the built-in buttons."),
+        class = "d-flex"
+      )
+    )
+  )
+}
+
+mod_overview_server <- function(id, term) {
+  moduleServer(id, function(input, output, session) {
+    counts <- shiny::reactive({
+      req(term())
+      df <- get_overview_counts(term())
+      if (!nrow(df)) {
+        tibble::tibble(
+          n_bills = NA_integer_, n_committees = NA_integer_,
+          n_legislators = NA_integer_, n_donors = NA_integer_, n_lobby_firms = NA_integer_
+        )
+      } else {
+        df
+      }
+    }) |>
+      shiny::bindCache(term())
+
+    output$bills_value <- shiny::renderUI({
+      value <- counts()$n_bills[1]
+      span(class = "metric-value", scales::comma(value))
+    })
+
+    output$committees_value <- shiny::renderUI({
+      value <- counts()$n_committees[1]
+      span(class = "metric-value", scales::comma(value))
+    })
+
+    output$legislators_value <- shiny::renderUI({
+      value <- counts()$n_legislators[1]
+      span(class = "metric-value", scales::comma(value))
+    })
+
+    output$money_value <- shiny::renderUI({
+      donors <- counts()$n_donors[1]
+      lobby <- counts()$n_lobby_firms[1]
+      span(class = "metric-value", sprintf("%s donors / %s lobby", scales::comma(donors), scales::comma(lobby)))
+    })
+  })
+}

--- a/shiny-app/R/modules/mod_people.R
+++ b/shiny-app/R/modules/mod_people.R
@@ -1,0 +1,168 @@
+mod_people_ui <- function(id) {
+  ns <- NS(id)
+  bslib::layout_sidebar(
+    sidebar = bslib::card(
+      bslib::card_header("Filters"),
+      bslib::card_body(
+        shiny::radioButtons(ns("people_tab"), "View", choices = c("Legislators", "Committees"), inline = TRUE),
+        shiny::checkboxGroupInput(ns("party_filter"), "Party", choices = c("D", "R"), selected = c("D", "R"), inline = TRUE),
+        shiny::checkboxGroupInput(ns("chamber_filter"), "Chamber", choices = c("Assembly", "Senate"), selected = c("Assembly", "Senate"), inline = TRUE),
+        shiny::helpText("Refine the leaderboard using party, chamber, and the global topic filter above.")
+      )
+    ),
+    bslib::layout_columns(
+      bslib::card(
+        bslib::card_header("Who stands out"),
+        bslib::card_body(
+          htmltools::tags$ul(id = ns("summary_points"), class = "mb-3"),
+          p("Selections reflect the current term and topic context.")
+        )
+      ),
+      bslib::card(
+        bslib::card_header("Leaders"),
+        bslib::card_body(DT::DTOutput(ns("leader_table")))
+      ),
+      bslib::card(
+        bslib::card_header("Detail"),
+        bslib::card_body(
+          plotly::plotlyOutput(ns("trend_chart"), height = 260),
+          DT::DTOutput(ns("drill_bills"))
+        )
+      )
+    )
+  )
+}
+
+mod_people_server <- function(id, term, topic, search) {
+  moduleServer(id, function(input, output, session) {
+    selected_entity <- shiny::reactiveVal(NULL)
+
+    people_data <- shiny::reactive({
+      req(term())
+      if (identical(input$people_tab, "Legislators")) {
+        df <- get_actor_overall(term())
+        if (nrow(df)) {
+          if ("actor_type" %in% names(df)) {
+            df <- df |> dplyr::filter(.data$actor_type == "Legislator")
+          }
+          if (!is.null(topic()) && topic() != TOPIC_ALL_LABEL) {
+            topic_df <- get_actor_topic(term(), topic())
+            if (nrow(topic_df)) {
+              df <- dplyr::left_join(df, topic_df, by = c("actor_name", "actor_type"), suffix = c("_overall", "_topic"))
+            }
+          }
+          if ("party" %in% names(df) && length(input$party_filter)) {
+            df <- df |> dplyr::filter(.data$party %in% input$party_filter)
+          }
+          if ("chamber" %in% names(df) && length(input$chamber_filter)) {
+            df <- df |> dplyr::filter(.data$chamber %in% input$chamber_filter)
+          }
+          if ("overall_influence" %in% names(df)) {
+            df <- df |> dplyr::arrange(dplyr::desc(.data$overall_influence))
+          }
+        }
+      } else {
+        df <- get_committee_metrics(term())
+        if (nrow(df) && length(input$chamber_filter) && "chamber" %in% names(df)) {
+          df <- df |> dplyr::filter(.data$chamber %in% input$chamber_filter)
+        }
+      }
+      df
+    }) |>
+      shiny::bindCache(term(), topic(), input$people_tab, input$party_filter, input$chamber_filter)
+
+    summary_points <- shiny::reactive({
+      df <- people_data()
+      if (!nrow(df)) return(character())
+      top_rows <- head(df, 3)
+      purrr::map_chr(seq_len(nrow(top_rows)), function(i) {
+        row <- top_rows[i, ]
+        name_col <- intersect(c("actor_name", "committee", "name"), names(row))[1]
+        metric_col <- intersect(c("overall_influence", "gatekeeping", "score", "median_weekly_bills"), names(row))[1]
+        if (is.na(name_col) || is.na(metric_col)) return("Data unavailable for summary.")
+        sprintf("%s ranks #%d with %s", row[[name_col]], i, scales::comma(row[[metric_col]]))
+      })
+    })
+
+    output$summary_points <- htmltools::renderTags({
+      items <- summary_points()
+      if (!length(items)) {
+        htmltools::tags$ul(htmltools::tags$li("No data available."))
+      } else {
+        htmltools::tags$ul(purrr::map(items, htmltools::tags$li))
+      }
+    })
+
+    output$leader_table <- DT::renderDT({
+      df <- people_data()
+      if (!nrow(df)) {
+        return(DT::datatable(tibble::tibble(message = "No results for these filters.")))
+      }
+      display_cols <- intersect(
+        c("actor_name", "party", "chamber", "overall_influence", "top_topic", "events", "support", "committee", "gatekeeping", "median_weekly_bills"),
+        names(df)
+      )
+      if (!length(display_cols)) display_cols <- names(df)
+      DT::datatable(
+        df |> dplyr::select(dplyr::all_of(display_cols)),
+        filter = "top",
+        selection = "single",
+        extensions = "Buttons",
+        options = list(pageLength = 15, dom = "Bfrtip", buttons = c("copy", "csv"))
+      )
+    })
+
+    proxy <- DT::dataTableProxy("leader_table")
+    observeEvent(search(), {
+      DT::updateSearch(proxy, keywords = list(global = search()))
+    })
+
+    observeEvent(input$leader_table_rows_selected, {
+      df <- people_data()
+      idx <- input$leader_table_rows_selected
+      if (length(idx) == 1 && idx <= nrow(df)) {
+        selected_entity(df[idx, , drop = FALSE])
+      }
+    })
+
+    output$trend_chart <- plotly::renderPlotly({
+      row <- selected_entity()
+      if (is.null(row)) {
+        return(plotly::plotly_empty())
+      }
+      name_col <- intersect(c("actor_name", "committee", "name"), names(row))[1]
+      if (is.na(name_col)) return(plotly::plotly_empty())
+      history <- get_actor_topic(term(), topic())
+      if (nrow(history) && name_col %in% names(history)) {
+        history <- history |> dplyr::filter(.data[[name_col]] == row[[name_col]])
+      }
+      if (!nrow(history)) {
+        return(plotly::plotly_empty())
+      }
+      history$score_val <- safe_pull(history, "score", NA_real_)
+      plotly::plot_ly(history, x = ~term, y = ~score_val, type = "scatter", mode = "lines+markers", name = "Score") |>
+        plotly::layout(xaxis = list(title = "Term"), yaxis = list(title = "Topic influence"))
+    })
+
+    output$drill_bills <- DT::renderDT({
+      row <- selected_entity()
+      if (is.null(row)) {
+        return(DT::datatable(tibble::tibble(message = "Select a row above to see related bills.")))
+      }
+      focus_topic <- if (!is.null(topic()) && topic() != TOPIC_ALL_LABEL) topic() else NULL
+      if (is.null(focus_topic)) {
+        return(DT::datatable(tibble::tibble(message = "Set a topic filter to see related bills.")))
+      }
+      bills <- get_topic_example_bills(focus_topic, term())
+      if (!nrow(bills)) {
+        return(DT::datatable(tibble::tibble(message = "No related bills found.")))
+      }
+      DT::datatable(
+        bills,
+        filter = "top",
+        extensions = "Buttons",
+        options = list(pageLength = 10, dom = "Bfrtip", buttons = c("copy", "csv"))
+      )
+    })
+  })
+}

--- a/shiny-app/R/modules/mod_topics.R
+++ b/shiny-app/R/modules/mod_topics.R
@@ -1,0 +1,205 @@
+mod_topics_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    div(class = "mb-3", "Compare issue areas across polarization, party unity, and funding. Click a card for details."),
+    bslib::layout_columns(
+      col_widths = c(4, 4, 4),
+      bslib::card(
+        bslib::card_header("Sort topics"),
+        bslib::card_body(
+          shiny::selectInput(
+            ns("sort_by"),
+            NULL,
+            choices = c("Polarization", "Party-line share", "Controversy", "Momentum"),
+            selected = "Polarization"
+          )
+        )
+      ),
+      bslib::card(
+        bslib::card_header("Minimum roll calls"),
+        bslib::card_body(
+          shiny::sliderInput(ns("min_rollcalls"), NULL, min = 0, max = 100, value = 10, step = 5)
+        )
+      ),
+      bslib::card(
+        bslib::card_header("Topic filter"),
+        bslib::card_body(
+          shiny::textOutput(ns("active_topic"))
+        )
+      )
+    ),
+    shiny::uiOutput(ns("topic_cards")),
+    shiny::uiOutput(ns("topic_detail"))
+  )
+}
+
+mod_topics_server <- function(id, term, topic_filter) {
+  moduleServer(id, function(input, output, session) {
+    selected_topic <- shiny::reactiveVal(NULL)
+
+    observeEvent(topic_filter(), {
+      if (!is.null(topic_filter()) && topic_filter() != TOPIC_ALL_LABEL) {
+        selected_topic(topic_filter())
+      }
+    })
+
+    output$active_topic <- shiny::renderText({
+      if (is.null(topic_filter()) || topic_filter() == TOPIC_ALL_LABEL) {
+        "All topics"
+      } else {
+        sprintf("Focused on: %s", topic_filter())
+      }
+    })
+
+    topics_data <- shiny::reactive({
+      req(term())
+      summary <- get_topic_summary(input$min_rollcalls)
+      if (!is.null(topic_filter()) && topic_filter() != TOPIC_ALL_LABEL) {
+        summary <- summary |> dplyr::filter(.data$topic == topic_filter())
+      }
+      current <- summary |> dplyr::filter(.data$term == term())
+      funding <- get_all_topic_funding()
+      funding_current <- funding |> dplyr::filter(.data$term == term())
+      combined <- dplyr::left_join(current, funding_current, by = c("topic", "term"))
+      if (!nrow(combined)) {
+        return(tibble::tibble())
+      }
+      combined$spark <- purrr::map(combined$topic, ~ summary |> dplyr::filter(.data$topic == .x) |> dplyr::arrange(.data$term))
+      combined$fund_trend <- purrr::map(combined$topic, ~ funding |> dplyr::filter(.data$topic == .x) |> dplyr::arrange(.data$term))
+      combined$sort_key <- dplyr::case_when(
+        input$sort_by == "Polarization" ~ combined$mean_polarization,
+        input$sort_by == "Party-line share" ~ combined$party_line_share,
+        input$sort_by == "Controversy" ~ safe_pull(combined, "controversiality", NA_real_),
+        input$sort_by == "Momentum" ~ safe_pull(combined, "momentum", NA_real_),
+        TRUE ~ combined$mean_polarization
+      )
+      combined |> dplyr::arrange(dplyr::desc(.data$sort_key))
+    }) |>
+      shiny::bindCache(term(), topic_filter(), input$min_rollcalls, input$sort_by)
+
+    observeEvent(topics_data(), {
+      df <- topics_data()
+      if (!nrow(df)) return()
+      current <- selected_topic()
+      if (is.null(current) || !current %in% df$topic) {
+        selected_topic(df$topic[[1]])
+      }
+    }, priority = -1)
+
+    observeEvent(topics_data(), {
+      df <- topics_data()
+      if (!nrow(df)) return(NULL)
+      purrr::walk(seq_len(nrow(df)), function(idx) {
+        topic_name <- df$topic[[idx]]
+        topic_id <- sanitize_id(topic_name)
+        spark_id <- paste0("spark_", topic_id)
+        fund_id <- paste0("fund_", topic_id)
+        spark_data <- df$spark[[idx]]
+        fund_data <- df$fund_trend[[idx]]
+        output[[spark_id]] <- plotly::renderPlotly({
+          validate(need(nrow(spark_data), ""))
+          plotly::plot_ly(spark_data, x = ~term, y = ~mean_polarization, type = "scatter", mode = "lines", showlegend = FALSE) |>
+            plotly::layout(margin = list(l = 10, r = 10, t = 10, b = 20), xaxis = list(title = NULL, showticklabels = FALSE), yaxis = list(title = NULL, showticklabels = FALSE))
+        })
+        output[[fund_id]] <- plotly::renderPlotly({
+          validate(need(nrow(fund_data), ""))
+          plotly::plot_ly(fund_data, x = ~term, y = ~total_received, type = "bar", showlegend = FALSE) |>
+            plotly::layout(margin = list(l = 10, r = 10, t = 10, b = 20), xaxis = list(title = NULL, showticklabels = FALSE), yaxis = list(title = NULL, showticklabels = FALSE))
+        })
+        shiny::observeEvent(input[[paste0("select_", topic_id)]], {
+          selected_topic(topic_name)
+        }, ignoreNULL = TRUE)
+      })
+    })
+
+    output$topic_cards <- shiny::renderUI({
+      df <- topics_data()
+      if (!nrow(df)) {
+        return(bslib::card(bslib::card_body("No topics available for the current filters.")))
+      }
+      cards <- purrr::imap(df$topic, function(topic_name, idx) {
+        topic_id <- sanitize_id(topic_name)
+        spark_id <- session$ns(paste0("spark_", topic_id))
+        fund_id <- session$ns(paste0("fund_", topic_id))
+        action_id <- session$ns(paste0("select_", topic_id))
+        stats <- df[idx, , drop = FALSE]
+        funding_total <- safe_pull(stats, "total_received", NA_real_)
+        minority <- safe_pull(stats, "minority_cross_rate", NA_real_)
+        card_body <- bslib::card_body(
+          div(class = "topic-metrics",
+              div(class = "sparkline", plotly::plotlyOutput(spark_id, height = 80)),
+              div(class = "fundspark", plotly::plotlyOutput(fund_id, height = 80))),
+          div(class = "mt-2", sprintf("Party-line votes: %s", fmt_pct0(stats$party_line_share))),
+          div(class = "text-muted", sprintf("Roll calls: %s", scales::comma(stats$n_rollcalls))),
+          if (!is.na(funding_total)) div(class = "text-muted", sprintf("Recent funding: %s", fmt_money(funding_total)))
+        )
+        bslib::card(
+          class = sprintf("topic-card %s", if (identical(selected_topic(), topic_name)) "selected" else ""),
+          bslib::card_header(
+            shiny::actionLink(action_id, label = topic_name, class = "topic-card-link")
+          ),
+          card_body
+        )
+      })
+      do.call(bslib::layout_columns, c(list(col_widths = rep(4, length(cards))), cards))
+    })
+
+    topic_detail_data <- shiny::reactive({
+      topic_name <- selected_topic()
+      if (is.null(topic_name)) return(NULL)
+      df <- topics_data()
+      if (!nrow(df) || !topic_name %in% df$topic) return(NULL)
+      list(
+        spark = df |> dplyr::filter(.data$topic == topic_name) |> dplyr::pull(.data$spark) |> purrr::pluck(1),
+        funding = df |> dplyr::filter(.data$topic == topic_name) |> dplyr::pull(.data$fund_trend) |> purrr::pluck(1),
+        bills = get_topic_example_bills(topic_name, term())
+      )
+    })
+
+    output$topic_detail <- shiny::renderUI({
+      detail <- topic_detail_data()
+      if (is.null(detail)) return(NULL)
+      ns <- session$ns
+      spark_plot_id <- ns("detail_polarization")
+      funding_plot_id <- ns("detail_funding")
+      output$detail_polarization <- plotly::renderPlotly({
+        df <- detail$spark
+        plotly::plot_ly(df, x = ~term, y = ~mean_polarization, type = "scatter", mode = "lines+markers", name = "Polarization") |>
+          plotly::layout(xaxis = list(title = "Term"), yaxis = list(title = "Mean polarization"))
+      })
+      output$detail_funding <- plotly::renderPlotly({
+        df <- detail$funding
+        plotly::plot_ly(df, x = ~term, y = ~total_received, type = "bar", name = "Funding") |>
+          plotly::layout(xaxis = list(title = "Term"), yaxis = list(title = "Total received"))
+      })
+      output$topic_example_bills <- DT::renderDT({
+        bills <- detail$bills
+        if (!nrow(bills)) {
+          return(DT::datatable(tibble::tibble(message = "No example bills for this topic.")))
+        }
+        if (!"bill_link" %in% names(bills) && "bill_ID" %in% names(bills)) {
+          bills$bill_link <- sprintf('<a href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=%s" target="_blank">view bill</a>', bills$bill_ID)
+        }
+        display <- bills |> dplyr::select(-dplyr::any_of(c("bill_id_raw")))
+        DT::datatable(
+          display,
+          filter = "top",
+          extensions = "Buttons",
+          escape = FALSE,
+          options = list(pageLength = 10, dom = "Bfrtip", buttons = c("copy", "csv"))
+        )
+      })
+      bslib::card(
+        class = "mt-4",
+        bslib::card_header(sprintf("Deep dive: %s", selected_topic())),
+        bslib::card_body(
+          bslib::layout_columns(
+            bslib::card(plotly::plotlyOutput(spark_plot_id, height = 260)),
+            bslib::card(plotly::plotlyOutput(funding_plot_id, height = 260))
+          ),
+          DT::DTOutput(ns("topic_example_bills"))
+        )
+      )
+    })
+  })
+}

--- a/shiny-app/R/router.R
+++ b/shiny-app/R/router.R
@@ -1,0 +1,26 @@
+# Routing helpers -----------------------------------------------------------------------
+
+parse_query <- function(session) {
+  shiny::parseQueryString(isolate(session$clientData$url_search))
+}
+
+encode_query <- function(params) {
+  if (!length(params)) return("")
+  pairs <- purrr::imap_chr(params, function(value, key) {
+    paste0(utils::URLencode(key, reserved = TRUE), "=", utils::URLencode(as.character(value), reserved = TRUE))
+  })
+  paste0("?", paste(pairs, collapse = "&"))
+}
+
+update_query <- function(session, params, mode = c("replace", "push")) {
+  mode <- match.arg(mode)
+  current <- parse_query(session)
+  merged <- modifyList(current, params)
+  merged <- merged[!vapply(merged, is.null, logical(1))]
+  shiny::updateQueryString(encode_query(merged), mode = mode, session = session)
+}
+
+get_query_value <- function(session, key, default = NULL) {
+  query <- parse_query(session)
+  if (!is.null(query[[key]])) query[[key]] else default
+}

--- a/shiny-app/R/theme.R
+++ b/shiny-app/R/theme.R
@@ -1,0 +1,21 @@
+#' Application theme configuration
+#'
+#' Defines the shared bslib theme for the dashboard, including
+#' typography, color palette, and dark-mode defaults.
+app_theme <- function() {
+  bslib::bs_theme(
+    version = 5,
+    preset = "bootstrap",
+    base_font = bslib::font_face(
+      family = "Inter",
+      file = "fonts/Inter-Variable.woff2",
+      weight = 400
+    ),
+    heading_font = bslib::font_face("Inter", file = "fonts/Inter-Variable.woff2"),
+    primary = "#2B4C7E",
+    secondary = "#0F766E",
+    success = "#0F766E",
+    light = "#f8f9fa",
+    dark = "#1f2933"
+  )
+}

--- a/shiny-app/R/utils.R
+++ b/shiny-app/R/utils.R
@@ -1,0 +1,62 @@
+# Utility helpers shared across modules -------------------------------------------------
+
+fmt_money <- function(x, digits = 0) {
+  if (is.null(x)) return(rep("—", length.out = length(x)))
+  res <- scales::dollar(x, accuracy = 1 / (10^digits), trim = TRUE)
+  res[is.na(x)] <- "—"
+  res
+}
+
+fmt_pct0 <- function(x) {
+  res <- scales::percent(x, accuracy = 1)
+  res[is.na(x)] <- "—"
+  res
+}
+
+fmt_pct1 <- function(x) {
+  res <- scales::percent(x, accuracy = 0.1)
+  res[is.na(x)] <- "—"
+  res
+}
+
+fmt_date <- function(x) {
+  if (inherits(x, "Date")) {
+    format(x, "%b %d, %Y")
+  } else {
+    x
+  }
+}
+
+pal_sequential <- function(n = 7L) {
+  grDevices::colorRampPalette(c("#e8f0fe", "#2B4C7E"))(n)
+}
+
+pal_diverging <- function(n = 7L) {
+  grDevices::colorRampPalette(c("#81312f", "#f5f2f0", "#0F766E"))(n)
+}
+
+rank_and_percentile <- function(x, decreasing = TRUE) {
+  if (!length(x)) {
+    return(list(rank = integer(), percentile = numeric()))
+  }
+  ord <- if (decreasing) -x else x
+  ranks <- rank(ord, ties.method = "min")
+  pct <- ranks / max(ranks)
+  list(rank = ranks, percentile = pct)
+}
+
+safe_pull <- function(data, column, default = NA) {
+  if (column %in% names(data)) {
+    data[[column]]
+  } else {
+    default
+  }
+}
+
+sanitize_id <- function(x) {
+  stringr::str_replace_all(tolower(x), "[^a-z0-9]+", "-")
+}
+
+with_cache <- function(expr, cache_key) {
+  shiny::bindCache(expr, cache_key, cache = shiny::cachem::cache_disk(dir = tempfile("shiny-cache-")))
+}

--- a/shiny-app/app.R
+++ b/shiny-app/app.R
@@ -1,0 +1,106 @@
+library(shiny)
+library(bslib)
+library(DT)
+library(plotly)
+library(leaflet)
+library(purrr)
+
+source("R/globals.R")
+source("R/theme.R")
+source("R/utils.R")
+source("R/load_data.R")
+source("R/router.R")
+
+module_files <- list.files("R/modules", full.names = TRUE)
+purrr::walk(module_files, source)
+
+TERMS <- tryCatch(get_available_terms(), error = function(e) character())
+if (!length(TERMS)) {
+  TERMS <- "2023-2024"
+}
+DEFAULT_TERM <- TERMS[[1]]
+TOPICS <- tryCatch(sort(unique(get_topic_summary(0)$topic)), error = function(e) character())
+
+ui <- function(request) {
+  page <- bslib::page_navbar(
+    title = mod_header_ui("header", TERMS, TOPICS),
+    id = "main_nav",
+    theme = app_theme(),
+    window_title = APP_TITLE,
+    collapsible = FALSE,
+    bslib::nav_panel("Overview", mod_overview_ui("overview")),
+    bslib::nav_panel("Money Map", mod_map_ui("map")),
+    bslib::nav_panel("Topics", mod_topics_ui("topics")),
+    bslib::nav_panel("People", mod_people_ui("people")),
+    bslib::nav_panel("Donors", mod_donors_ui("donors")),
+    bslib::nav_panel("Bills", mod_bills_ui("bills")),
+    footer = NULL
+  )
+  tagList(
+    page,
+    tags$head(tags$link(rel = "stylesheet", href = "css/styles.css")),
+    tags$script("Shiny.addCustomMessageHandler('copy-url', function(message) { navigator.clipboard.writeText(message.url); });")
+  )
+}
+
+default_page <- "Overview"
+
+default_state <- function(session) {
+  list(
+    page = get_query_value(session, "page", default_page),
+    term = get_query_value(session, "term", DEFAULT_TERM),
+    topic = get_query_value(session, "topic", TOPIC_ALL_LABEL),
+    search = get_query_value(session, "search", "")
+  )
+}
+
+server <- function(input, output, session) {
+  state <- default_state(session)
+
+  header_state <- mod_header_server("header", state$term, function() {
+    update_query(session, list(
+      page = input$main_nav,
+      term = header_state$term(),
+      topic = header_state$topic(),
+      search = if (nzchar(header_state$search())) header_state$search() else NULL
+    ))
+  })
+
+  observeEvent(TRUE, {
+    if (!is.null(state$page)) {
+      bslib::nav_select(session, "main_nav", state$page)
+    }
+    header_state$update_term(state$term)
+    header_state$update_topic(state$topic)
+    header_state$update_search(state$search)
+  }, once = TRUE)
+
+  observeEvent(header_state$search(), {
+    update_query(session, list(
+      page = input$main_nav,
+      term = header_state$term(),
+      topic = header_state$topic(),
+      search = if (nzchar(header_state$search())) header_state$search() else NULL
+    ), mode = "replace")
+  })
+
+  observeEvent(input$main_nav, {
+    update_query(session, list(
+      page = input$main_nav,
+      term = header_state$term(),
+      topic = header_state$topic(),
+      search = if (nzchar(header_state$search())) header_state$search() else NULL
+    ), mode = "replace")
+  })
+
+  mod_overview_server("overview", header_state$term)
+  mod_map_server("map", header_state$term, header_state$topic)
+  mod_topics_server("topics", header_state$term, header_state$topic)
+  mod_people_server("people", header_state$term, header_state$topic, header_state$search)
+  mod_donors_server("donors", header_state$term, header_state$topic, header_state$search)
+  mod_bills_server("bills", header_state$term, header_state$topic, header_state$search)
+}
+
+enableBookmarking("url")
+
+shinyApp(ui, server)

--- a/shiny-app/www/css/styles.css
+++ b/shiny-app/www/css/styles.css
@@ -1,0 +1,41 @@
+.app-title {
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.header-controls .form-select,
+.header-controls .form-control {
+  min-height: 2.25rem;
+}
+
+.metric-card .metric-value {
+  font-size: 2.25rem;
+  font-weight: 600;
+}
+
+.topic-card.selected {
+  border: 2px solid var(--bs-primary);
+}
+
+.topic-card-link {
+  display: inline-block;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.topic-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+
+.entity-overlay {
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.card .card-body p:last-child {
+  margin-bottom: 0;
+}

--- a/shiny-app/www/fonts/Inter-Variable.woff2
+++ b/shiny-app/www/fonts/Inter-Variable.woff2
@@ -1,0 +1,1 @@
+Placeholder for Inter Variable font. Replace with actual font file.


### PR DESCRIPTION
## Summary
- scaffold the Shiny navbar application with global header controls and theming
- add memoised data loaders for the precomputed parquet and geo assets
- implement overview, map, topics, people, donors, and bills modules with tables, charts, and maps plus supporting CSS

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905379b22f88324ba79aefc91cf6729